### PR TITLE
Do not test using fixed etags

### DIFF
--- a/schema.xsd
+++ b/schema.xsd
@@ -15,7 +15,7 @@
                             <xs:element name="regular" type="whatsNewInfo" minOccurs="1" maxOccurs="1" />
                             <xs:element name="admin" type="whatsNewInfo" minOccurs="0" maxOccurs="1" />
                         </xs:sequence>
-                        <xs:attribute name="lang" type="xs:language" use="required" />
+                        <xs:attribute name="lang" type="language" use="required" />
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
@@ -28,6 +28,15 @@
             <xs:pattern value="(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"/>
             <xs:minLength value="6"/>
             <xs:maxLength value="12"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- based on xs:language, just uses _ as a separator between lang and region. -->
+    <xs:simpleType name="language">
+        <xs:restriction base="xs:token">
+            <xs:pattern
+                    value="([a-zA-Z]{2}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(_[a-zA-Z]{1,8})*"
+            />
         </xs:restriction>
     </xs:simpleType>
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -75,28 +75,15 @@ class FeatureContext implements SnippetAcceptingContext {
 	}
 
 	/**
-	 * @Given /^the received Etag is "([^"]*)"$/
+	 * @Given /^the response contains$/
 	 * @throws Exception
 	 */
-	public function theReceivedEtagIs($expectedEtag)
+	public function theResponseContains(\Behat\Gherkin\Node\PyStringNode $expectedResponse)
 	{
-		if($expectedEtag !== $this->responseEtag) {
-			throw new \Exception(
-				'Etag was expected to be ' . $expectedEtag
-				. ', but actually is ' . $this->responseEtag
-			);
-		}
-	}
+		if(strpos(trim($this->responseBody),trim($expectedResponse)) === false) {
 
-	/**
-	 * @Given /^the response is$/
-	 * @throws Exception
-	 */
-	public function theResponseIs(\Behat\Gherkin\Node\PyStringNode $expectedResponse)
-	{
-		if(trim($expectedResponse) !== trim($this->responseBody)) {
 			throw new \Exception(
-				'The response body was expected to be ' . $expectedResponse
+				'The response body was expected to contain ' . $expectedResponse
 				. ', but actually is ' . $this->responseBody
 			);
 		}
@@ -116,5 +103,13 @@ class FeatureContext implements SnippetAcceptingContext {
 	public function theKnownEtagIs($etag)
 	{
 		$this->knownEtag = $etag;
+	}
+
+	/**
+	 * @Given /^remembering the received Etag$/
+	 */
+	public function rememberingTheReceivedEtag()
+	{
+		$this->knownEtag = $this->responseEtag;
 	}
 }

--- a/tests/integration/features/whatsNew.feature
+++ b/tests/integration/features/whatsNew.feature
@@ -21,11 +21,8 @@ Feature: testing the response of the Changelog Server
     Given the version of interest is "13.0.0"
     When the request is sent
     Then the return code is "200"
-    And the received Etag is "3fb8717553d719e65caa0eafcee0b191"
-    And the response is
+    And the response contains
     """
-    <?xml version="1.0" encoding="utf-8"?>
-    <release xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schema.xsd" version="13.0.0">
       <changelog href="https://nextcloud.com/changelog/#13-0-0"/>
       <whatsNew lang="en">
         <regular>
@@ -38,46 +35,58 @@ Feature: testing the response of the Changelog Server
           <item>Theming: CSS files were consolidated</item>
         </admin>
       </whatsNew>
-    </release>
     """
 
   Scenario: Request against a valid version, expecting info
     Given the version of interest is "14.0.0"
     When the request is sent
     Then the return code is "200"
-    And the received Etag is "1cb8496aba7de138528af2206fddaf35"
-
-  Scenario: Request against a valid version with matching an valid etag
-    Given the version of interest is "13.0.0"
-    And the known Etag is "3fb8717553d719e65caa0eafcee0b191"
-    When the request is sent
-    Then the return code is "304"
-    And the response is empty
-
-  Scenario: Request against a valid version with matching an valid etag
-    Given the version of interest is "14.0.0"
-    And the known Etag is "1cb8496aba7de138528af2206fddaf35"
-    When the request is sent
-    Then the return code is "304"
-    And the response is empty
-
-  Scenario: Request against a valid version with outdated etag
-    Given the version of interest is "14.0.0"
-    And the known Etag is "abcdefabcdef00011122233344455566"
-    When the request is sent
-    Then the return code is "200"
-    And the received Etag is "1cb8496aba7de138528af2206fddaf35"
-
-  Scenario: Request against a valid version with outdated etag
-    Given the version of interest is "13.0.0"
-    And the known Etag is "abcdefabcdef00011122233344455566"
-    When the request is sent
-    Then the return code is "200"
-    And the received Etag is "3fb8717553d719e65caa0eafcee0b191"
-    And the response is
+    And the response contains
     """
-    <?xml version="1.0" encoding="utf-8"?>
-    <release xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../schema.xsd" version="13.0.0">
+      <changelog href="https://nextcloud.com/changelog/#14-0-0"/>
+      <whatsNew lang="en">
+        <regular>
+          <item>Verify a share recipient in a video call; 2FA with Signal &amp; Telegram</item>
+          <item>Add a note to shares; extended share views; search by comments</item>
+          <item>Accessibility improvements including high contrast theme</item>
+        </regular>
+        <admin>
+          <item>Requires PHP &gt;= 7.0, log format, syslog tag &amp; nginx config changed</item>
+          <item>Improved GDPR compliance through apps; separate audit log</item>
+          <item>Kerberos auth to Samba; multi-IdP SAML</item>
+        </admin>
+      </whatsNew>
+    """
+
+  Scenario: Request against a valid version with matching an valid etag
+    Given the version of interest is "13.0.0"
+    And the request is sent
+    And remembering the received Etag
+    When the request is sent
+    Then the return code is "304"
+    And the response is empty
+
+  Scenario: Request against a valid version with matching an valid etag
+    Given the version of interest is "14.0.0"
+    And the request is sent
+    And remembering the received Etag
+    When the request is sent
+    Then the return code is "304"
+    And the response is empty
+
+  Scenario: Request against a valid version with outdated etag
+    Given the version of interest is "14.0.0"
+    And the known Etag is "abcdefabcdef00011122233344455566"
+    When the request is sent
+    Then the return code is "200"
+
+  Scenario: Request against a valid version with outdated etag
+    Given the version of interest is "13.0.0"
+    And the known Etag is "abcdefabcdef00011122233344455566"
+    When the request is sent
+    Then the return code is "200"
+    And the response contains
+    """
       <changelog href="https://nextcloud.com/changelog/#13-0-0"/>
       <whatsNew lang="en">
         <regular>
@@ -90,5 +99,4 @@ Feature: testing the response of the Changelog Server
           <item>Theming: CSS files were consolidated</item>
         </admin>
       </whatsNew>
-    </release>
     """


### PR DESCRIPTION
Integration tests cannot take a fixed etag into account as it changes
when translations are being merged.

Signed-off-by: Arthur Schiwon <blizzz@arthur-schiwon.de>