### PR TITLE
make the clients cache 404s

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -26,7 +26,7 @@ class Response {
 			. 'xml';
 
 		if(!file_exists($path)) {
-			header('HTTP/1.1 404 Not Found');
+			header("Etag: " . md5(''));
 			return;
 		}
 

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -112,4 +112,18 @@ class FeatureContext implements SnippetAcceptingContext {
 	{
 		$this->knownEtag = $this->responseEtag;
 	}
+
+	/**
+	 * @Given /^the etag is "([^"]*)"$/
+	 * @throws Exception
+	 */
+	public function theEtagIs(string $expectedEtag)
+	{
+		if($expectedEtag !== $this->responseEtag) {
+			throw new \Exception(
+				'The response etag was expected to be ' . $expectedEtag
+				. ', but actually is ' . $this->responseEtag
+			);
+		}
+	}
 }

--- a/tests/integration/features/whatsNew.feature
+++ b/tests/integration/features/whatsNew.feature
@@ -3,7 +3,8 @@ Feature: testing the response of the Changelog Server
     Given the version of interest is "11.0.0"
     When the request is sent
     Then the response is empty
-    And the return code is "404"
+    And the return code is "200"
+    And the etag is "d41d8cd98f00b204e9800998ecf8427e"
 
   Scenario: Request against an invalid version (wrong format)
     Given the version of interest is "eleven oh oh"


### PR DESCRIPTION
since we usually have what's new info only for major releases. This does
not need to be rerequested so often.

* [x] test with an instance

fixes #22 